### PR TITLE
Removed conflict with Web interface

### DIFF
--- a/src/AppiumDriver.php
+++ b/src/AppiumDriver.php
@@ -33,7 +33,6 @@ use Codeception\TestInterface;
 class AppiumDriver extends CodeceptionModule implements
     MultiSessionInterface,
     ScreenshotSaver,
-    ConflictsWithModule,
     RequiresPackage
 {
     use BaseCommands;
@@ -115,11 +114,6 @@ class AppiumDriver extends CodeceptionModule implements
                 $e->getMessage() . "\n \nPlease make sure that Selenium Server or PhantomJS is running."
             );
         }
-    }
-
-    public function _conflicts()
-    {
-        return 'Codeception\Lib\Interfaces\Web';
     }
 
     public function _before(TestInterface $test)


### PR DESCRIPTION
Because AppiumDriver does not implement it.

This will allow to use AppiumDriver in the same test suite with WebDriver, PhpBrowser or even framework modules.

https://github.com/Codeception/Codeception/issues/4693